### PR TITLE
Replace activities with Olympic sports only

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -21,59 +21,59 @@ app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
 
 # In-memory activity database
 activities = {
-    "Chess Club": {
-        "description": "Learn strategies and compete in chess tournaments",
-        "schedule": "Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 12,
+    "Swimming": {
+        "description": "Train in freestyle, backstroke, breaststroke, and butterfly events",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 20,
         "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
     },
-    "Programming Class": {
-        "description": "Learn programming fundamentals and build software projects",
-        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
-        "max_participants": 20,
+    "Track and Field": {
+        "description": "Sprint, jump, and throw in various athletic disciplines",
+        "schedule": "Tuesdays and Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
         "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
     },
-    "Gym Class": {
-        "description": "Physical education and sports activities",
-        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
-        "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
-    },
-    "Basketball Team": {
-        "description": "Competitive basketball team and practice sessions",
+    "Gymnastics": {
+        "description": "Practice floor, vault, beam, and bar routines",
         "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
         "max_participants": 15,
-        "participants": ["james@mergington.edu"]
+        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
     },
-    "Tennis Club": {
-        "description": "Learn tennis techniques and participate in matches",
-        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:00 PM",
+    "Fencing": {
+        "description": "Learn foil, epee, and sabre techniques and compete in bouts",
+        "schedule": "Tuesdays, 3:30 PM - 5:00 PM",
         "max_participants": 12,
-        "participants": ["sarah@mergington.edu"]
+        "participants": ["lucas@mergington.edu", "mia@mergington.edu"]
     },
-    "Drama Club": {
-        "description": "Stage acting, theater productions, and performance art",
+    "Archery": {
+        "description": "Develop precision and focus in target and recurve archery",
         "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
-        "max_participants": 25,
-        "participants": ["lucas@mergington.edu", "nina@mergington.edu"]
+        "max_participants": 14,
+        "participants": ["liam@mergington.edu", "ava@mergington.edu"]
     },
-    "Art Studio": {
-        "description": "Painting, drawing, sculpture, and visual arts",
-        "schedule": "Mondays and Fridays, 3:30 PM - 4:30 PM",
-        "max_participants": 18,
-        "participants": ["grace@mergington.edu"]
-    },
-    "Science Club": {
-        "description": "Explore scientific concepts through experiments and projects",
+    "Rowing": {
+        "description": "Train in singles, doubles, and team rowing on the water",
         "schedule": "Thursdays, 4:00 PM - 5:30 PM",
-        "max_participants": 20,
-        "participants": ["alex@mergington.edu", "maya@mergington.edu"]
-    },
-    "Debate Team": {
-        "description": "Public speaking, argumentation, and competitive debate",
-        "schedule": "Tuesdays, 4:00 PM - 5:30 PM",
         "max_participants": 16,
-        "participants": ["david@mergington.edu"]
+        "participants": ["noah@mergington.edu", "isabella@mergington.edu"]
+    },
+    "Judo": {
+        "description": "Learn throws, holds, and competition techniques in judo",
+        "schedule": "Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": ["amelia@mergington.edu", "benjamin@mergington.edu"]
+    },
+    "Volleyball": {
+        "description": "Practice serves, spikes, and team strategies for indoor volleyball",
+        "schedule": "Mondays, 4:00 PM - 5:30 PM",
+        "max_participants": 12,
+        "participants": ["charlotte@mergington.edu", "elijah@mergington.edu"]
+    },
+    "Table Tennis": {
+        "description": "Sharpen reflexes and spin techniques in singles and doubles play",
+        "schedule": "Wednesdays, 4:00 PM - 5:00 PM",
+        "max_participants": 10,
+        "participants": ["harper@mergington.edu", "james@mergington.edu"]
     }
 }
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -19,7 +19,7 @@ def safe_unregister(activity: str, email: str):
 
 
 def test_signup_and_unregister_flow():
-    activity = "Chess Club"
+    activity = "Swimming"
     email = "test_user@example.com"
 
     # ensure clean state
@@ -45,7 +45,7 @@ def test_signup_and_unregister_flow():
 
 
 def test_duplicate_signup_returns_400():
-    activity = "Programming Class"
+    activity = "Track and Field"
     email = "dup_user@example.com"
 
     # ensure clean state
@@ -65,7 +65,7 @@ def test_duplicate_signup_returns_400():
 
 
 def test_unregister_nonexistent_returns_404():
-    activity = "Tennis Club"
+    activity = "Fencing"
     email = "noone@example.com"
 
     # ensure not present


### PR DESCRIPTION
## Summary\n\nReplaced all extracurricular activities with **Olympic sports only**.\n\n### Changes\n- **`src/app.py`**: Replaced 9 general activities with 9 Olympic sports:\n  - Swimming\n  - Track and Field\n  - Gymnastics\n  - Fencing\n  - Archery\n  - Rowing\n  - Judo\n  - Volleyball\n  - Table Tennis\n\n- **`tests/test_app.py`**: Updated all test references to use the new activity names.\n\n### Testing\nAll 3 tests pass.